### PR TITLE
Add OneSwapIndexUnsort etc.

### DIFF
--- a/unsort.go
+++ b/unsort.go
@@ -12,11 +12,20 @@ import (
 // Init PRNG
 func init() { rand.Seed(time.Now().UnixNano()) }
 
-// Unsorting algorithm
-func Unsort(list []string) []string {
+// Basic two swap index unsorting algorithm
+func BasicUnsort(list []string) []string {
 	for range list {
 		swapindex1, swapindex2 := rand.Intn(len(list)), rand.Intn(len(list))
 		list[swapindex1], list[swapindex2] = list[swapindex2], list[swapindex1]
+	}
+	return list
+}
+
+// Unsorting algorithm with one swap index
+func OneSwapIndexUnsort(list []string) []string {
+	for i := len(list)-1; i >= 1; i-- {
+		swapindex := rand.Intn(i+1)
+		list[swapindex], list[i] = list[i], list[swapindex]
 	}
 	return list
 }
@@ -28,5 +37,20 @@ func main() {
 	scanner.Scan()
 	liststr := scanner.Text()
 	list := strings.Split(liststr, " ")
-	fmt.Printf("%v\n", Unsort(list))
+	fmt.Println("Choose an unsorting func:")
+	for {
+		fmt.Println("0=BasicUnsort, 1=OneSwapIndexUnsort")
+		var unsortindex int
+		fmt.Scanf("%d", &unsortindex)
+		switch unsortindex {
+		case 0:
+			fmt.Printf("%v\n", BasicUnsort(list))
+			return
+		case 1:
+			fmt.Printf("%v\n", OneSwapIndexUnsort(list))
+			return
+		default:
+			fmt.Println("Please enter a valid index.")
+		}
+	}
 }

--- a/unsort_test.go
+++ b/unsort_test.go
@@ -8,22 +8,19 @@ import (
 )
 
 var sorted = []string{"0","1","2","3","4","5","6","7","8","9"}
-var counter = map[string]int{
-	"0": 0, 
-	"1": 0, 
-	"2": 0,
-	"3": 0, 
-	"4": 0, 
-	"5": 0, 
-	"6": 0, 
-	"7": 0, 
-	"8": 0, 
-	"9": 0,
-}
 
 func UnsortTestTemplate (b *testing.B, name string, Unsort func([]string)[]string) {
-	for k, _ := range counter {
-		counter[k] = 0
+	counter := map[string]int{
+		"0": 0, 
+		"1": 0, 
+		"2": 0,
+		"3": 0, 
+		"4": 0, 
+		"5": 0, 
+		"6": 0, 
+		"7": 0, 
+		"8": 0, 
+		"9": 0,
 	}
 	fmt.Println(name)
 	b.StartTimer()

--- a/unsort_test.go
+++ b/unsort_test.go
@@ -4,45 +4,36 @@ import (
 	"fmt"
 	"math"
 	"encoding/json"
-	"flag"
 	"testing"
 )
 
-type unsortfuncpair struct {
-	name string
-	Run func([]string) []string
+var sorted = []string{"0","1","2","3","4","5","6","7","8","9"}
+var counter = map[string]int{
+	"0": 0, 
+	"1": 0, 
+	"2": 0,
+	"3": 0, 
+	"4": 0, 
+	"5": 0, 
+	"6": 0, 
+	"7": 0, 
+	"8": 0, 
+	"9": 0,
 }
 
-var ufindex = flag.Int("func", 0, "Specify the unsort function to be used by its index. 0=BasicUnsort, 1=OneSwapIndexUnsort")
-
-func TestUnsort(t *testing.T) {
-	unsortoptions := []unsortfuncpair {
-		{"Basic unsort", BasicUnsort},
-		{"One swap index unsort", OneSwapIndexUnsort},
+func UnsortTestTemplate (b *testing.B, name string, Unsort func([]string)[]string) {
+	for k, _ := range counter {
+		counter[k] = 0
 	}
-	sorted := []string{"0","1","2","3","4","5","6","7","8","9"}
-	counter := map[string]int{
-		"0": 0,
-		"1": 0,
-		"2": 0,
-		"3": 0,
-		"4": 0,
-		"5": 0,
-		"6": 0,
-		"7": 0,
-		"8": 0,
-		"9": 0,
+	fmt.Println(name)
+	b.StartTimer()
+	for j := 0; j < b.N; j++ {
+		for i := 0; i < 100000; i++ {
+			unsorted := Unsort(sorted)
+			counter[unsorted[0]]++
+		}
 	}
-	if *ufindex < 0 || *ufindex > 1 {
-		t.Errorf("Invalid unsort function index")
-		return
-	}
-	unsortfunc := unsortoptions[*ufindex]
-	fmt.Printf("--- %s ---\n", unsortfunc.name)
-	for i := 100000; i > 0; i-- {
-		unsorted := unsortfunc.Run(sorted)
-		counter[unsorted[0]]++
-	}
+	b.StopTimer()
 	leastvalue := ""
 	leastcount := math.Inf(1)
 	mostvalue := ""
@@ -61,6 +52,15 @@ func TestUnsort(t *testing.T) {
 	}
 	tenpercent := mostcount / 10
 	if float64(mostcount - tenpercent) > leastcount {
-		t.Errorf("%s (most common @ %d) is more common than %s (least common @ %d) by over 10 percent", mostvalue, mostcount, leastvalue, int(leastcount))
+		b.Errorf("%s (most common @ %d) is more common than %s (least common @ %d) by over 10 percent", mostvalue, mostcount, leastvalue, int(leastcount))
 	}
 }
+
+func BenchmarkBasicUnsort(b *testing.B) {
+	UnsortTestTemplate(b, "Basic unsort", BasicUnsort);
+}
+
+func BenchmarkOneSwapIndexUnsort(b *testing.B) {
+	UnsortTestTemplate(b, "One swap index unsort", OneSwapIndexUnsort);
+}
+

--- a/unsort_test.go
+++ b/unsort_test.go
@@ -4,10 +4,22 @@ import (
 	"fmt"
 	"math"
 	"encoding/json"
+	"flag"
 	"testing"
 )
 
+type unsortfuncpair struct {
+	name string
+	Run func([]string) []string
+}
+
+var ufindex = flag.Int("func", 0, "Specify the unsort function to be used by its index. 0=BasicUnsort, 1=OneSwapIndexUnsort")
+
 func TestUnsort(t *testing.T) {
+	unsortoptions := []unsortfuncpair {
+		{"Basic unsort", BasicUnsort},
+		{"One swap index unsort", OneSwapIndexUnsort},
+	}
 	sorted := []string{"0","1","2","3","4","5","6","7","8","9"}
 	counter := map[string]int{
 		"0": 0,
@@ -21,8 +33,14 @@ func TestUnsort(t *testing.T) {
 		"8": 0,
 		"9": 0,
 	}
+	if *ufindex < 0 || *ufindex > 1 {
+		t.Errorf("Invalid unsort function index")
+		return
+	}
+	unsortfunc := unsortoptions[*ufindex]
+	fmt.Printf("--- %s ---\n", unsortfunc.name)
 	for i := 100000; i > 0; i-- {
-		unsorted := Unsort(sorted)
+		unsorted := unsortfunc.Run(sorted)
 		counter[unsorted[0]]++
 	}
 	leastvalue := ""


### PR DESCRIPTION
Rename Unsort to BasicUnsort.
Add OneSwapIndexUnsort, a more efficient unsorting algorithm than the basic one.
Permit the user to choose between the unsorting algorithm to be used in unsort.go:main.
Add the -func flag to unsort_test.go, which can be used to specify a particular unsorting algorithm